### PR TITLE
There is no extra package bird6 in Debian 9

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,8 +16,16 @@
 #   The service name used by puppet ressource
 #   Default: bird6
 #
+# [*package_name_v6*]
+#   The package name used by puppet ressource
+#   Default: bird6
+#
 # [*daemon_name_v4*]
 #   The service name used by puppet ressource
+#   Default: bird
+#
+# [*package_name_v4*]
+#   The package name used by puppet ressource
 #   Default: bird
 #
 # [*config_path_v6*]
@@ -84,6 +92,7 @@
 #
 class bird (
   $daemon_name_v4     = $bird::params::daemon_name_v4,
+  $package_name_v4    = $bird::params::package_name_v4,
   $config_path_v4     = $bird::params::config_path_v4,
   $config_file_v4     = 'UNSET',
   $config_template_v4 = 'UNSET',
@@ -95,6 +104,7 @@ class bird (
   $service_v4_ensure  = 'running',
   $service_v4_enable  = false,
   $daemon_name_v6     = $bird::params::daemon_name_v6,
+  $package_name_v6    = $bird::params::package_name_v6,
   $config_path_v6     = $bird::params::config_path_v6,
   $config_file_v6     = 'UNSET',
   $config_template_v6 = 'UNSET',
@@ -110,10 +120,7 @@ class bird (
   validate_re($service_v6_ensure,['^running','^stopped'])
   validate_re($service_v4_ensure,['^running','^stopped'])
 
-  package {
-    $daemon_name_v4:
-      ensure => installed;
-  }
+  ensure_packages([$package_name_v4], {'ensure' => 'present'})
 
   if $manage_service == true {
     service {
@@ -124,7 +131,7 @@ class bird (
         restart    => '/usr/sbin/birdc configure',
         hasstatus  => false,
         pattern    => $daemon_name_v4,
-        require    => Package[$daemon_name_v4];
+        require    => Package[$package_name_v4];
     }
   }
 
@@ -141,7 +148,7 @@ class bird (
             group   => root,
             mode    => '0644',
             notify  => Service[$daemon_name_v4],
-            require => Package[$daemon_name_v4];
+            require => Package[$package_name_v4];
         }
       } else {
         file {
@@ -152,7 +159,7 @@ class bird (
             group   => root,
             mode    => '0644',
             notify  => Service[$daemon_name_v4],
-            require => Package[$daemon_name_v4];
+            require => Package[$package_name_v4];
         }
       } # config_file_v4
     } # config_tmpl_v4
@@ -160,10 +167,7 @@ class bird (
 
   if $enable_v6 == true {
 
-    package {
-      $daemon_name_v6:
-        ensure => installed;
-    }
+    ensure_packages([$package_name_v6], {'ensure' => 'present'})
 
     if $manage_service == true {
       service {
@@ -174,7 +178,7 @@ class bird (
           restart    => '/usr/sbin/birdc6 configure',
           hasstatus  => false,
           pattern    => $daemon_name_v6,
-          require    => Package[$daemon_name_v6];
+          require    => Package[$package_name_v6];
       }
     }
 
@@ -191,7 +195,7 @@ class bird (
               group   => root,
               mode    => '0644',
               notify  => Service[$daemon_name_v6],
-              require => Package[$daemon_name_v6];
+              require => Package[$package_name_v6];
           }
         } else {
           file {
@@ -202,7 +206,7 @@ class bird (
               group   => root,
               mode    => '0644',
               notify  => Service[$daemon_name_v6],
-              require => Package[$daemon_name_v6];
+              require => Package[$package_name_v6];
           }
         } # config_file_v6
       } # config_tmpl_v6

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,11 @@ class bird::params {
       $daemon_name_v4   = 'bird'
       $daemon_name_v6   = 'bird6'
       $package_name_v4  = 'bird'
-      $package_name_v6  = 'bird6'
+      if $::facts['os']['release']['major'] == '9' {
+        $package_name_v6  = 'bird'
+      } else {
+        $package_name_v6  = 'bird6'
+      }
     }
     'RedHat': {
       $config_path_v4   = '/etc/bird.conf'


### PR DESCRIPTION
Use variables defined in params.pp correctly.
Update default package name for Debian 9.

I'm sorry. I don't know how to work with puppet tests yet.
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
